### PR TITLE
Update Serialized.py

### DIFF
--- a/Week_5/Serialized.py
+++ b/Week_5/Serialized.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 	lock = threading.Lock()
 	threads = []
 	for _ in range(4):
-		thread = threading.Thread(target=increment(lock))
+		thread = threading.Thread(target=increment, args=(lock,))
 		threads.append(thread)
 		thread.start()
 


### PR DESCRIPTION
Passing increment function correctly to the thread with args=(lock,). Prevents the function from being called immediately and allows it to run with the lock argument when the thread starts.